### PR TITLE
Syntaro apps error handling

### DIFF
--- a/PSModule/ModernWorkplaceClientCenter/Functions/Get-MDMMsiApp.ps1
+++ b/PSModule/ModernWorkplaceClientCenter/Functions/Get-MDMMsiApp.ps1
@@ -59,7 +59,7 @@ function Get-MDMMsiApp() {
                         Add-Member -InputObject $AppTemp -MemberType NoteProperty -Name "LocURI" -Value $App.LocURI
                         #Check if App is from Syntaro
                         $SyntaroApp = $null
-                        $SyntaroApps = Get-ChildItem -Path HKLM:\SOFTWARE\Syntaro\ApplicationManagement\
+                        $SyntaroApps = Get-ChildItem -Path HKLM:\SOFTWARE\Syntaro\ApplicationManagement\ -ErrorAction SilentlyContinue
                         foreach($TempSyntaroApp in $SyntaroApps){
                             if((Get-ItemProperty -Path $TempSyntaroApp.PSPath).MsiCode -eq $App.PSChildName){
                                 $SyntaroApp = (Get-ItemProperty -Path $TempSyntaroApp.PSPath)


### PR DESCRIPTION
Currently, when you run the Get-MdmMsiApp function, if child items in the HKLM:\SOFTWARE\Syntaro\ApplicationManagement\ path are not found, errors are displayed in the console. Adding -ErrorAction SilentlyContinue stops these errors from showing in the console.